### PR TITLE
Don't let Rack::Static send a response until after we introspect a response from the API first

### DIFF
--- a/app/acme_app.rb
+++ b/app/acme_app.rb
@@ -8,16 +8,22 @@ module Acme
           :urls => %w[/]
         })
     end
+
     def call(env)
-      request_path = env['PATH_INFO']      
-      # static files
-      @filenames.each do |path|
-        response = @rack_static.call(env.merge({'PATH_INFO' => request_path + path}))
-        return response if response[0] != 404
-      end
       # api
       response = Acme::API.call(env)
-      # error pages
+
+      # Check if the App wants us to pass the response along to others
+      if response[1]['X-Cascade'] == 'pass'
+        # static files
+        request_path = env['PATH_INFO']
+        @filenames.each do |path|
+          response = @rack_static.call(env.merge({'PATH_INFO' => request_path + path}))
+          return response if response[0] != 404
+        end
+      end
+
+      # Serve error pages or respond with API response
       case response[0]
       when 404, 500
         @rack_static.call(env.merge({'PATH_INFO' => "/errors/#{response[0]}.html"}))


### PR DESCRIPTION
This is my fix for an message I posted to the group.  However, the message appears to be gone.  Otherwise, I'd post this pull request to it.

Don't let Rack::Static send a response until after we introspect a response from the API first. If Rack wants us to try to pass along to other middlewares with X-Cascade, then look for static files to serve.
