### PR TITLE
Expose potential leaks

### DIFF
--- a/spec/api/ping_spec.rb
+++ b/spec/api/ping_spec.rb
@@ -8,7 +8,8 @@ describe Acme::API do
   end
 
   before(:all) do
-    @stats = OStats.new filters: ['Grape'], suppress_nodelta: true
+    @stats = OStats.new filters: ['Grape'], suppress_nodelta: true,
+      trace_allocations: true
     @stats.collect!
   end
 

--- a/spec/api/ping_spec.rb
+++ b/spec/api/ping_spec.rb
@@ -7,6 +7,16 @@ describe Acme::API do
     Acme::API
   end
 
+  before(:all) do
+    @stats = OStats.new filters: ['Grape'], suppress_nodelta: true
+    @stats.collect!
+  end
+
+  after(:all) do
+    @stats.collect!
+    @stats.display
+  end
+
   it 'ping' do
     get '/api/ping'
     expect(last_response.status).to eq(200)

--- a/spec/ostats_helper.rb
+++ b/spec/ostats_helper.rb
@@ -21,9 +21,9 @@ class OStats
     @stats[-1].sort {|(k1,v1),(k2,v2)| v2 <=> v1}.each do |k,v|
       delta = ((v - @stats[-2][k]) unless @stats[-2].nil?) || 0
       if !@suppress_nodelta or delta != 0
-        printf "%-60s %10d", k, v
+        printf "%-50s %6d", k, v
         if !@suppress_nodelta or delta != 0
-          printf " delta %10d", delta
+          printf " delta %6d", delta
         end
         puts
       end

--- a/spec/ostats_helper.rb
+++ b/spec/ostats_helper.rb
@@ -1,0 +1,32 @@
+class OStats
+  def initialize options
+    @filters = (options.delete :filters) || ['']
+    @suppress_nodelta = options.delete :suppress_nodelta
+    @stats = Array.new
+  end
+
+  def collect!
+    stats = Hash.new(0)
+
+    ObjectSpace.each_object do |o|
+      @filters.each do |f|
+        stats[o.class] += 1 if o.class.name.start_with? f
+      end
+    end
+
+    @stats << stats
+  end
+
+  def display
+    @stats[-1].sort {|(k1,v1),(k2,v2)| v2 <=> v1}.each do |k,v|
+      delta = ((v - @stats[-2][k]) unless @stats[-2].nil?) || 0
+      if !@suppress_nodelta or delta != 0
+        printf "%-60s %10d", k, v
+        if !@suppress_nodelta or delta != 0
+          printf " delta %10d", delta
+        end
+        puts
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'rubygems'
+require 'ostats_helper'
 
 ENV['RACK_ENV'] ||= 'test'
 


### PR DESCRIPTION
Following the discussion around [issue #665 in intridea/grape](https://github.com/intridea/grape/issues/665), this PR adds some contextual information when running the spec on the Ping API (`bundle exec rspec spec/api/ping_spec.rb`). Please note that the tests themselves have not been changed, only additional information is being displayed.

If you need the tests to expose the issue by actually testing for it and failing, please let me know. Upon running the ping spec, you should see something along the lines of:

```
Grape::Route                                                         87 delta         71
Grape::Util::HashStack                                               68 delta         28
Grape::Endpoint                                                      55 delta         28
```

Please also note that sometimes, two other classes seem to not be properly GC'd, however I don't know how relevant this is to the issue at hand.

```
Grape::Route                                                         87 delta         71
Grape::Util::HashStack                                               68 delta         28
Grape::Endpoint                                                      56 delta         29
Grape::Request                                                        1 delta          1
Grape::Cookies                                                        1 delta          1
```
