### PR TITLE
minor code improvements

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,0 @@
---color
---format=documentation
-

--- a/api/entities.rb
+++ b/api/entities.rb
@@ -6,7 +6,6 @@ module Acme
       expose :length, documentation: { type: :string, desc: 'length of the tool' }
       expose :weight, documentation: { type: :string, desc: 'weight of the tool' }
       expose :foo, documentation: { type: :string, desc: 'foo' }, if: ->(_tool, options) { options[:foo] } do |_tool, options|
-        # p options[:env].keys
         options[:foo]
       end
     end

--- a/api/post_put.rb
+++ b/api/post_put.rb
@@ -1,8 +1,7 @@
 module Acme
   class PostPut < Grape::API
-    class << self
-      attr_accessor :rang
-    end
+    cattr_accessor :rang
+
     format :json
     desc 'Returns pong.'
     get :ring do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,9 @@ require 'rack/test'
 require File.expand_path('../../config/environment', __FILE__)
 
 RSpec.configure do |config|
+  config.color = true
+  config.formatter = :documentation
+
   config.mock_with :rspec
   config.expect_with :rspec
   config.raise_errors_for_deprecations!


### PR DESCRIPTION
* removed an unnecessary commented line of code

* replaced `attr_accessor` declared within a class's `self` block with a [`cattr_accessor`](http://apidock.com/rails/Class/cattr_accessor)

* moved settings from the .rspec file into the spec_helper, thereby removing the need for an extra file