### PR TITLE
Migrate from deprecated xvfb action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: browser-actions/setup-firefox@v1
         with:
           firefox-version: "111.0.1"
-      - uses: GabrielBB/xvfb-action@v1
+      - uses: coactions/setup-xvfb@v1
         with:
           run: |
             bundle exec rake spec


### PR DESCRIPTION
Old action is deprecated and will not be updated. Migrate to suggested replacement that uses Node 16. Drop in replacement.