### PR TITLE
Remove Code Climate badge, document stream_file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,18 @@ $ curl -X POST -i -F file=@spec/fixtures/grape_logo.png http://localhost:9292/ap
 HTTP/1.1 201 Created
 Content-Type: image/png
 Content-Disposition: attachment; filename*=UTF-8''grape_logo.png
+Cache-Control: no-cache
 Vary: Origin
-Content-Length: 4272
-Server: WEBrick/1.4.2 (Ruby/2.6.5/2019-10-01)
-Date: Sat, 18 Jun 2022 02:12:21 GMT
-Connection: Keep-Alive
+Transfer-Encoding: chunked
+```
+
+Download the streamed response to a file and verify it's identical to the upload.
+
+```
+$ curl -X POST -F file=@spec/fixtures/grape_logo.png http://localhost:9292/api/download_stream -o grape_logo_downloaded.png
+$ cmp spec/fixtures/grape_logo.png grape_logo_downloaded.png && echo "identical"
+
+identical
 ```
 
 ### [entites](api/entities.rb)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Grape API on Rack
 =================
 
 [![Test](https://github.com/ruby-grape/grape-on-rack/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/ruby-grape/grape-on-rack/actions/workflows/test.yml)
-[![Code Climate](https://codeclimate.com/github/ruby-grape/grape-on-rack.svg)](https://codeclimate.com/github/ruby-grape/grape-on-rack)
 
 A [Grape](http://github.com/ruby-grape/grape) API mounted on Rack.
 
@@ -212,6 +211,23 @@ module Acme
     end
   end
 end
+```
+
+### [stream_file](api/stream_file.rb)
+
+An example that streams a file upload/download through an IO-like interface instead of reading the whole file into memory (see [`upload_file`](api/upload_file.rb) for the in-memory equivalent).
+
+```
+$ curl -X POST -i -F file=@spec/fixtures/grape_logo.png http://localhost:9292/api/download_stream
+
+HTTP/1.1 201 Created
+Content-Type: image/png
+Content-Disposition: attachment; filename*=UTF-8''grape_logo.png
+Vary: Origin
+Content-Length: 4272
+Server: WEBrick/1.4.2 (Ruby/2.6.5/2019-10-01)
+Date: Sat, 18 Jun 2022 02:12:21 GMT
+Connection: Keep-Alive
 ```
 
 ### [entites](api/entities.rb)


### PR DESCRIPTION
## Why

Code Climate is no longer set up for this repository, so its badge in the README is stale/broken. Also, the `stream_file` example (added in #92) was never documented in the README.

## Changes

- Remove the Code Climate badge from `README.md`.
- Add a `stream_file` section documenting `api/stream_file.rb`, alongside the existing `upload_file` example.
